### PR TITLE
Fixed sorting of osm changesets

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -113,7 +113,7 @@ osmStream.runFn(function(err, data) {
             f.feature.linestring.length > 4;
     }).sort(function(a, b) {
         return (+new Date(a.meta.tilestamp)) -
-            (+new Date(a.meta.tilestamp));
+            (+new Date(b.meta.tilestamp));
     });
     // if (queue.length > 2000) queue = queue.slice(0, 2000);
     runSpeed = 1500;


### PR DESCRIPTION
The sorting function for the osm stream data is erroneous:

```
function (a, b) { return (+new Date(a.meta.tilestamp)) - (+new Date(a.meta.tilestamp)); }
```

`b` is never used, instead `a` is used twice, resulting in a sort value which is always 0. The correct function is probably (note the `b` in the subtrahend):

```
function (a, b) { return (+new Date(a.meta.tilestamp)) - (+new Date(b.meta.tilestamp)); }
```
