### PR TITLE
Fix the initial zoom value in overview map

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -42,7 +42,7 @@ var overview_map = L.map('overview_map', {
     scrollWheelZoom: false,
     doubleClickZoom: false,
     boxZoom: false
-}).setView([51.505, -0.09], 1);
+}).setView([51.505, -0.09], 4);
 
 var bing = new L.BingLayer(BING_KEY, 'Aerial').addTo(map);
 

--- a/js/site.js
+++ b/js/site.js
@@ -41,7 +41,7 @@ var overview_map = L.map('overview_map', {
     scrollWheelZoom: false,
     doubleClickZoom: false,
     boxZoom: false
-}).setView([51.505, -0.09], 1);
+}).setView([51.505, -0.09], 4);
 
 var bing = new L.BingLayer(BING_KEY, 'Aerial').addTo(map);
 


### PR DESCRIPTION
The overview map has the initial zoom (and center) hard-coded;
 however, the current zoom is not available from the map layer.
 Setting this to 4 gives the minimal zoom,
 thus the overview map actually loads.

This is not an issue when updates from OSM arrive,
 as the center and zoom is then correctly loaded, dynamically;
 the fix only concerns the very first map load.