### PR TITLE
Bounded overpass query

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -6,19 +6,19 @@ var osmStream = require('osm-stream'),
     LRU = require('lru-cache'),
     query_string = require('querystring');
 
-var bboxString = ["-90.0", "-180.0", "90.0", "180.0"];
+var bboxArray = ["-90.0", "-180.0", "90.0", "180.0"];
 var mapCenter = [51.505, -0.09];
 var filteredBbox = false;
 var changeset_comment_match = null;
 if (location.hash) {
     var parsed_hash = query_string.parse(location.hash.replace('#', ''));
-    if (parsed_hash.length == 1 && parsed_hash[Object.keys(parsed_hash)[0]] === null) {
+    if (parsed_hash.length === 1 && parsed_hash[Object.keys(parsed_hash)[0]] === null) {
         // To be backwards compatible with pages that assumed the only
         // item in the hash would be the bbox
-        bboxString = Object.keys(parsed_hash)[0].split(',');
+        bboxArray = Object.keys(parsed_hash)[0].split(',');
     } else {
         if (parsed_hash.bounds) {
-            bboxString = parsed_hash.bounds.split(',');
+            bboxArray = parsed_hash.bounds.split(',');
             filteredBbox = true;
         }
         if (parsed_hash.comment) {
@@ -27,10 +27,8 @@ if (location.hash) {
     }
 }
 
-var bbox = new L.LatLngBounds(
-    new L.LatLng(+bboxString[0], +bboxString[1]),
-    new L.LatLng(+bboxString[2], +bboxString[3]));
-
+var bbox = makeBbox(bboxArray);
+var bboxString = filteredBbox ? bbox.toBBoxString() : null;
 
 var ignore = ['bot-mode'];
 var BING_KEY = 'Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU';
@@ -169,7 +167,7 @@ osmStream.runFn(function(err, data) {
     });
     // if (queue.length > 2000) queue = queue.slice(0, 2000);
     runSpeed = 1500;
-});
+}, null, null, bboxString);
 
 function doDrawWay() {
     document.getElementById('queuesize').innerHTML = queue.length;

--- a/js/site.js
+++ b/js/site.js
@@ -5,19 +5,19 @@ var osmStream = require('osm-stream'),
     LRU = require('lru-cache'),
     query_string = require('querystring');
 
-var bboxString = ["-90.0", "-180.0", "90.0", "180.0"];
+var bboxArray = ["-90.0", "-180.0", "90.0", "180.0"];
 var mapCenter = [51.505, -0.09];
 var filteredBbox = false;
 var changeset_comment_match = null;
 if (location.hash) {
     var parsed_hash = query_string.parse(location.hash.replace('#', ''));
-    if (parsed_hash.length == 1 && parsed_hash[Object.keys(parsed_hash)[0]] === null) {
+    if (parsed_hash.length === 1 && parsed_hash[Object.keys(parsed_hash)[0]] === null) {
         // To be backwards compatible with pages that assumed the only
         // item in the hash would be the bbox
-        bboxString = Object.keys(parsed_hash)[0].split(',');
+        bboxArray = Object.keys(parsed_hash)[0].split(',');
     } else {
         if (parsed_hash.bounds) {
-            bboxString = parsed_hash.bounds.split(',');
+            bboxArray = parsed_hash.bounds.split(',');
             filteredBbox = true;
         }
         if (parsed_hash.comment) {
@@ -26,10 +26,8 @@ if (location.hash) {
     }
 }
 
-var bbox = new L.LatLngBounds(
-    new L.LatLng(+bboxString[0], +bboxString[1]),
-    new L.LatLng(+bboxString[2], +bboxString[3]));
-
+var bbox = makeBbox(bboxArray);
+var bboxString = filteredBbox ? bbox.toBBoxString() : null;
 
 var ignore = ['bot-mode'];
 var BING_KEY = 'Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU';
@@ -168,7 +166,7 @@ osmStream.runFn(function(err, data) {
     });
     // if (queue.length > 2000) queue = queue.slice(0, 2000);
     runSpeed = 1500;
-});
+}, null, null, bboxString);
 
 function doDrawWay() {
     document.getElementById('queuesize').innerHTML = queue.length;


### PR DESCRIPTION
Overpass API at `/api/augmented_diff` now allows for bounded queries: http://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs

> bbox= is optional and is a min_lon,min_lat,max_lon,max_lat limited bounding box of the area of interest

`osmstream` likewise supports bbox as a parameter.

This may reduce the diffs from multiple MB to a few kB, depending on the size of the bounding box - which further reduces the amount of processing that is required client-side.

Fixes #49 - not applied when SMTW runs unbounded.