### PR TITLE
Set maxZoom for overview map.

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -56,7 +56,8 @@ var overview_map = L.map('overview_map', {
     scrollWheelZoom: false,
     doubleClickZoom: false,
     boxZoom: false,
-    minZoom: 4
+    minZoom: 4,
+    maxZoom: 8
 });
 if (filteredBbox) {
     overview_map.fitBounds(bbox);

--- a/js/site.js
+++ b/js/site.js
@@ -55,7 +55,8 @@ var overview_map = L.map('overview_map', {
     scrollWheelZoom: false,
     doubleClickZoom: false,
     boxZoom: false,
-    minZoom: 4
+    minZoom: 4,
+    maxZoom: 8
 });
 if (filteredBbox) {
     overview_map.fitBounds(bbox);


### PR DESCRIPTION
If not specified, setting a tiny bounding box only shows a black square, as the tiles are only specified for a small zoom range.
This forces the zoom range on both sides, which always gives a valid map.

(Yes, this is a tiny PR; should have though of it when setting minZoom, sorry about that.)