### PR TITLE
Display nodes that have tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
 </div>
     <script id='changeset-template' type='template'>
 <% var past_tense = { modify: 'modified', create: 'created', 'delete': 'deleted' }; %>
-<p><a target='_blank' href='//openstreetmap.org/browse/changeset/<%=change.meta.changeset%>'><%=change.timetext%></a> <a target='_blank' href='//openstreetmap.org/user/<%= change.meta.user %>'><%= change.meta.user %></a>
-     <%= past_tense[change.type] %> <a target='_blank' href='//openstreetmap.org/browse/<%= change.meta.type %>/<%= change.meta.id %>'><%= change.tagtext %></a>
+<p><a target='_blank' href='//openstreetmap.org/browse/changeset/<%-change.meta.changeset%>'><%-change.timetext%></a> <a target='_blank' href='//openstreetmap.org/user/<%- change.meta.user %>'><%- change.meta.user %></a>
+     <%- past_tense[change.type] %> <a target='_blank' href='//openstreetmap.org/browse/<%- change.meta.type %>/<%- change.meta.id %>'><%- change.tagtext %></a>
     </p>
     </script>
     <script src='//cdnjs.cloudflare.com/ajax/libs/leaflet/0.5/leaflet.js'></script>

--- a/js/site.js
+++ b/js/site.js
@@ -233,14 +233,15 @@ function pruneMapElements() {
 function setTagText(change) {
     var showTags = ['building', 'natural', 'leisure', 'waterway',
         'barrier', 'landuse', 'highway', 'power'];
+    var mapElement = change.type === 'delete' ? change.old : change.neu;
+    var tags = mapElement.tags;
     for (var i = 0; i < showTags.length; i++) {
-        var tags = change.type === 'delete' ? change.old.tags : change.neu.tags;
         if (tags[showTags[i]]) {
             change.tagtext = showTags[i] + '=' + tags[showTags[i]];
             return change;
         }
     }
-    change.tagtext = 'a way';
+    change.tagtext = 'a ' + mapElement.type;
     return change;
 }
 

--- a/js/site.js
+++ b/js/site.js
@@ -166,7 +166,7 @@ osmStream.runFn(function(err, data) {
         if (is_a_way) {
             var bbox_intersects_old = (f.old && f.old.bounds && bbox.intersects(makeBbox(f.old.bounds)));
             var bbox_intersects_new = (f.neu && f.neu.bounds && bbox.intersects(makeBbox(f.neu.bounds)));
-            var happened_today = moment((f.neu && f.neu.timestamp) || (f.neu && f.neu.timestamp)).format("MMM Do YY") === moment().format("MMM Do YY");
+            var happened_today = moment(f.neu && f.neu.timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
             var user_not_ignored = (f.old && ignore.indexOf(f.old.user) === -1) || (f.neu && ignore.indexOf(f.neu.user) === -1);
             var way_long_enough = (f.old && f.old.linestring && f.old.linestring.length > 4) || (f.neu && f.neu.linestring && f.neu.linestring.length > 4);
             return is_a_way &&
@@ -178,8 +178,8 @@ osmStream.runFn(function(err, data) {
             return false;
         }
     }).sort(function(a, b) {
-        return (+new Date((a.neu && a.neu.timestamp) || (a.neu && a.neu.timestamp))) -
-            (+new Date((b.neu && b.neu.timestamp) || (b.neu && b.neu.timestamp)));
+        return (+new Date((a.neu && a.neu.timestamp))) -
+            (+new Date((b.neu && b.neu.timestamp)));
     });
     // if (queue.length > 2000) queue = queue.slice(0, 2000);
     runSpeed = 1500;

--- a/js/site.js
+++ b/js/site.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var osmStream = require('osm-stream'),
     reqwest = require('reqwest'),
     moment = require('moment'),
@@ -119,7 +121,7 @@ function showLocation(ll) {
 }
 
 function fetchChangesetData(id, callback) {
-    cached_changeset_data = changeset_cache.get(id);
+    var cached_changeset_data = changeset_cache.get(id);
 
     if (!cached_changeset_data) {
         var changeset_url_tmpl = '//www.openstreetmap.org/api/0.6/changeset/{id}';
@@ -270,6 +272,7 @@ function drawWay(change, cb) {
     changeset_info.innerHTML = changeset_tmpl({ change: change });
 
     var color = { 'create': '#B7FF00', 'modify': '#FF00EA', 'delete': '#FF0000' }[change.type];
+    var newLine;
     if (way.tags.building || way.tags.area) {
         newLine = L.polygon([], {
             opacity: 1,

--- a/js/site.js
+++ b/js/site.js
@@ -169,8 +169,7 @@ osmStream.runFn(function(err, data) {
             var happened_today = moment(f.neu && f.neu.timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
             var user_not_ignored = (f.old && ignore.indexOf(f.old.user) === -1) || (f.neu && ignore.indexOf(f.neu.user) === -1);
             var way_long_enough = (f.old && f.old.linestring && f.old.linestring.length > 4) || (f.neu && f.neu.linestring && f.neu.linestring.length > 4);
-            return is_a_way &&
-                (bbox_intersects_old || bbox_intersects_new) &&
+            return (bbox_intersects_old || bbox_intersects_new) &&
                 happened_today &&
                 user_not_ignored &&
                 way_long_enough;

--- a/js/site.js
+++ b/js/site.js
@@ -158,6 +158,15 @@ function makeBbox(bounds_array) {
     );
 }
 
+function happenedToday(timestamp) {
+    return moment(timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
+}
+
+function userNotIgnored(change) {
+    return (change.old && ignore.indexOf(change.old.user) === -1)
+        || (change.neu && ignore.indexOf(change.neu.user) === -1);
+}
+
 var runSpeed = 2000;
 
 osmStream.runFn(function(err, data) {
@@ -167,8 +176,8 @@ osmStream.runFn(function(err, data) {
             case 'way':
                 var bbox_intersects_old = (f.old && f.old.bounds && bbox.intersects(makeBbox(f.old.bounds)));
                 var bbox_intersects_new = (f.neu && f.neu.bounds && bbox.intersects(makeBbox(f.neu.bounds)));
-                var happened_today = moment(f.neu && f.neu.timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
-                var user_not_ignored = (f.old && ignore.indexOf(f.old.user) === -1) || (f.neu && ignore.indexOf(f.neu.user) === -1);
+                var happened_today = happenedToday(f.neu && f.neu.timestamp);
+                var user_not_ignored = userNotIgnored(f);
                 var way_long_enough = (f.old && f.old.linestring && f.old.linestring.length > 4) || (f.neu && f.neu.linestring && f.neu.linestring.length > 4);
                 return (bbox_intersects_old || bbox_intersects_new) &&
                     happened_today &&

--- a/js/site.js
+++ b/js/site.js
@@ -162,19 +162,20 @@ var runSpeed = 2000;
 
 osmStream.runFn(function(err, data) {
     queue = _.filter(data, function(f) {
-        var is_a_way = (f.old && f.old.type === 'way') || (f.neu && f.neu.type === 'way');
-        if (is_a_way) {
-            var bbox_intersects_old = (f.old && f.old.bounds && bbox.intersects(makeBbox(f.old.bounds)));
-            var bbox_intersects_new = (f.neu && f.neu.bounds && bbox.intersects(makeBbox(f.neu.bounds)));
-            var happened_today = moment(f.neu && f.neu.timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
-            var user_not_ignored = (f.old && ignore.indexOf(f.old.user) === -1) || (f.neu && ignore.indexOf(f.neu.user) === -1);
-            var way_long_enough = (f.old && f.old.linestring && f.old.linestring.length > 4) || (f.neu && f.neu.linestring && f.neu.linestring.length > 4);
-            return (bbox_intersects_old || bbox_intersects_new) &&
-                happened_today &&
-                user_not_ignored &&
-                way_long_enough;
-        } else {
-            return false;
+        var type = (f.old && f.old.type) || (f.neu && f.neu.type);
+        switch (type) {
+            case 'way':
+                var bbox_intersects_old = (f.old && f.old.bounds && bbox.intersects(makeBbox(f.old.bounds)));
+                var bbox_intersects_new = (f.neu && f.neu.bounds && bbox.intersects(makeBbox(f.neu.bounds)));
+                var happened_today = moment(f.neu && f.neu.timestamp).format("MMM Do YY") === moment().format("MMM Do YY");
+                var user_not_ignored = (f.old && ignore.indexOf(f.old.user) === -1) || (f.neu && ignore.indexOf(f.neu.user) === -1);
+                var way_long_enough = (f.old && f.old.linestring && f.old.linestring.length > 4) || (f.neu && f.neu.linestring && f.neu.linestring.length > 4);
+                return (bbox_intersects_old || bbox_intersects_new) &&
+                    happened_today &&
+                    user_not_ignored &&
+                    way_long_enough;
+            default:
+                return false;
         }
     }).sort(function(a, b) {
         return (+new Date((a.neu && a.neu.timestamp))) -

--- a/js/site.js
+++ b/js/site.js
@@ -115,7 +115,7 @@ function showLocation(ll) {
         crossOrigin: true,
         type: 'json'
     }, function(resp) {
-        document.getElementById('reverse-location').innerHTML =
+        document.getElementById('reverse-location').textContent =
             '' + resp.display_name + '';
     });
 }
@@ -147,7 +147,7 @@ function fetchChangesetData(id, callback) {
 
 function showComment(id) {
     fetchChangesetData(id, function(err, changeset_data) {
-        document.getElementById('comment').innerHTML = changeset_data.comment + ' in ' + changeset_data.created_by;
+        document.getElementById('comment').textContent = changeset_data.comment + ' in ' + changeset_data.created_by;
     });
 }
 
@@ -186,7 +186,7 @@ osmStream.runFn(function(err, data) {
 }, null, null, bboxString);
 
 function doDrawWay() {
-    document.getElementById('queuesize').innerHTML = queue.length;
+    document.getElementById('queuesize').textContent = queue.length;
     if (queue.length) {
         var change = queue.pop();
         var way = change.neu || change.old;

--- a/js/site.js
+++ b/js/site.js
@@ -333,11 +333,28 @@ function drawMapElement(change, cb) {
             drawPt(mapElement.linestring.pop());
             break;
         case 'node':
-            L.circleMarker([mapElement.lat, mapElement.lon], {
+            // Calculate marker radii such that final radius is ~10px
+            var radii = [];
+            for (var i = 0; i <= 25; i += 1) {
+                radii.push(17 * Math.sin(i / 10));
+            }
+            var newMarker = L.circleMarker([mapElement.lat, mapElement.lon], {
                 opacity: 1,
                 color: color
             }).addTo(mapElementGroup);
-            window.setTimeout(cb, runSpeed);
+
+            var perRadius = runSpeed / radii.length;
+            function nodeMarkerAnimation() {
+                newMarker.setRadius(radii.shift());
+                if (radii.length) {
+                    window.setTimeout(nodeMarkerAnimation, perRadius);
+                }
+                else {
+                    window.setTimeout(cb, perRadius * 2);
+                }
+            }
+
+            nodeMarkerAnimation();
             break;
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "see OSM edits happen in real time",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "browserify js/site.js > js/bundle.js"
   },
   "repository": "",
   "author": "",
@@ -16,5 +17,8 @@
     "reqwest": "~0.7.2",
     "moment": "~2.0.0",
     "lru-cache": "~4.0.0"
+  },
+  "devDependencies": {
+    "browserify": "16.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "osm-stream": "0.0.13",
+    "osm-stream": "osmlab/osm-stream#v0.0.14",
     "ration": "0.0.0",
     "underscore": "~1.4.4",
     "reqwest": "~0.7.2",


### PR DESCRIPTION
Issue #56 requested that nodes should also be displayed. The suggested changes in this pull request add this functionality by placing a marker for nodes that have been created, modified or deleted if the node has any tags.
Since this requires that tags are also part of the data structure that is provided by [`osm-stream`](https://github.com/osmlab/osm-stream), it currently has no visible effect though, since tag parsing for nodes only becomes available if/when osmlab/osm-stream#13 (or something similar) gets merged, which currently has a syntax error that could be fixed by applying a trivial patch like the one in mstock/osm-stream@56bf6bd5158ade7eb0fad83d48c746156e4e833e. Once that pull request is merged, somebody would have to cut a release of [`osm-stream`](https://github.com/osmlab/osm-stream) and then the corresponding dependency in [`show-me-the-way`](https://github.com/osmlab/show-me-the-way) would need updating.
The first five commits in this pull request are mainly smaller code cleanups and fixes - I can extract them to a different branch and create a separate pull request or even drop them if you prefer.
For demonstration purposes, I've deployed a build with the node feature that uses a patched version of [`osm-stream`](https://github.com/osmlab/osm-stream) [on my Github page](https://mstock.github.io/show-me-the-way/).