### PR TITLE
Retry diff retrieval at most once

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -9,6 +9,7 @@ var osmStream = require('osm-stream'),
 
 var bboxArray = ["-90.0", "-180.0", "90.0", "180.0"];
 var mapCenter = [51.505, -0.09];
+const maxDiffRetries = 1;
 var filteredBbox = false;
 var changeset_comment_match = null;
 if (location.hash) {
@@ -213,7 +214,7 @@ osmStream.runFn(function(err, data) {
     });
     // if (queue.length > 2000) queue = queue.slice(0, 2000);
     runSpeed = 1500;
-}, null, null, bboxString);
+}, null, null, bboxString, maxDiffRetries);
 
 function doDrawMapElement() {
     document.getElementById('queuesize').textContent = queue.length;


### PR DESCRIPTION
This should improve robustness since it eventually results in skipping diffs that cannot be retrieved/processed for some reason. Please note that for this to have any effect, osmlab/osm-stream#14 must be merged and released first and the new version referenced from `package.json`. For testing purposes, I've built and released a version with these changes on https://mstock.github.io/show-me-the-way/.