### PR TITLE
Introduce key filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Build a bounding box URL using this page: https://osmlab.github.io/show-me-the-w
     - https://osmlab.github.io/show-me-the-way/#comment=missingmaps
     - `comment=missingmaps`, will only show changes where the changeset comment contained missingmaps somewhere
 
+### Filter by feature keys
+
+- key={string}
+- Restrict viewing only edits where the changeset's features include keys equal to a string.
+    - https://osmlab.github.io/show-me-the-way/#key=building
+    - `key=building`, will only show changes where the changeset includes features with the key building
+
 ### Change the playback speed
 
 - runTime={seconds}

--- a/js/change.js
+++ b/js/change.js
@@ -84,30 +84,32 @@ class Change {
 
     isRelevant() {
         return new Promise((resolve) => {
-            let relevant = false;
+            let commentRelevance = false;
+            let keyRelevance = false;
             const mapElement = this.neu || this.old;
 
-            if (this.context.comment == "") {
+            if (this.context.comment === "" && !this.context.key) {
                 return resolve(true);
-            }
+            }        
 
             this.fetchChangesetData(mapElement.changeset)
                 .then((changesetData) => {
-                    relevant = (
-                        changesetData.comment &&
-                        changesetData.comment.toLowerCase()
-                            .indexOf(this.context.comment.toLowerCase()) > -1
-                    );
 
-                    if (!relevant) {
+                    commentRelevance = 
+                        this.context.comment !== "" && 
+                        changesetData.comment?.toLowerCase()
+                            .includes(this.context.comment.toLowerCase()) || false;
+
+                    keyRelevance = Object.keys(mapElement.tags).includes(this.context.key);
+
+                    if (!(commentRelevance || keyRelevance)) {
                         console.log(
                             "Skipping map element " + mapElement.id
-                            + " because changeset " + mapElement.changeset
-                            + " didn't match " + this.context.comment
+                            + " because it didn't match filters."
                         );
                     }
 
-                    return resolve(relevant);
+                    return resolve(commentRelevance | keyRelevance);
                 });
         });
     }

--- a/js/change.js
+++ b/js/change.js
@@ -90,7 +90,7 @@ class Change {
 
             if (this.context.comment === "" && !this.context.key) {
                 return resolve(true);
-            }        
+            }
 
             this.fetchChangesetData(mapElement.changeset)
                 .then((changesetData) => {


### PR DESCRIPTION
Awesome project! Thanks for making it open-source.

I created a version where users are allowed to filter on keys of edited features as well, in addition to the existing changeset comment filter.

**How did I test my changes?**

I built (`docker build --tag show-me-the-way .`) and run (`docker run --rm --publish 8080:8080 --name show-me-the-way-container show-me-the-way`) a Docker container using this `Dockerfile`:

```
FROM node:18
WORKDIR /usr/src/app
COPY . .
RUN npm install
RUN npm run build
RUN npm install -g http-server
EXPOSE 8080
CMD ["http-server", ".", "-p", "8080"]
```

Then I observed the page for these 3 URLs:

http://127.0.0.1:8080/#key=power
http://127.0.0.1:8080/#comment=Specify
http://127.0.0.1:8080/

Using the first URL, I got many power-related edits. Using the second, I got many edits made mostly via StreetComplete (_Specify_ is a common word in changeset comments there). Using the third link, I got changesets without key or comment filters.

I hope this PR is useful, if not, or it's technically not sound, I hope you'll say so; and I'll try my best to address concerns.