### PR TITLE
Playback multiple edits at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Build a bounding box URL using this page: https://osmlab.github.io/show-me-the-w
     - https://osmlab.github.io/show-me-the-way/#runTime=5
     - The default runTime is 2.
 
+### Disable multi-edit playback
+
+- multi={true|false}
+- When enabled (default), nearby edits from the same changeset are drawn simultaneously.
+- Set to false to show one edit at a time.
+    - https://osmlab.github.io/show-me-the-way/#multi=false
+
 You can combine the parameters using querystring notation:
 
 - https://osmlab.github.io/show-me-the-way/#comment=missingmaps&bounds=32.55,-15.82,71.65,44.65&runTime=5

--- a/js/config.js
+++ b/js/config.js
@@ -4,5 +4,6 @@ export const config = {
     'bounds': '-90,-180,90,180',
     'comment': '',
     'runTime': 2,
+    'multi': true,
     'debug': false
 };


### PR DESCRIPTION
https://github.com/user-attachments/assets/25319872-967c-401d-871a-ad7bd174dc26

- When more than 5 edits in the same changeset are within 1km of each other, 4–7 elements draw concurrently with randomly offset start times and varied speeds (0.5x–3x).
- Disable with `multi=false` querystring to restore single-edit playback

cc @iandees 